### PR TITLE
Update Resque Dependency

### DIFF
--- a/resque-dynamic-queues.gemspec
+++ b/resque-dynamic-queues.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency("resque", '~> 1.10')
+  s.add_dependency("resque", '>= 1.10', '< 3.0')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('rspec', '~> 2.5')
@@ -30,4 +30,3 @@ Gem::Specification.new do |s|
   s.add_development_dependency('json')
 
 end
-


### PR DESCRIPTION
Updates the resque dependency to allow for versions up to 3. Specs are passing w/ version 2.0.